### PR TITLE
Only pulish coverage for a PR

### DIFF
--- a/.github/workflows/libipcon_main.yml
+++ b/.github/workflows/libipcon_main.yml
@@ -73,6 +73,7 @@ jobs:
           cat $COVERAGE_MD
 
       - name: Post Coverage Data to PR
+        if: ${{ github.event_name == 'pull_request' }}
         uses: JoseThen/comment-pr@v1.2.0
         with:
           file_path: "./coverage.md"


### PR DESCRIPTION
# Issue

Test workflow triggered by push events fails because there is no PR to post the coverage result.