### PR TITLE
Fix coverage report format (lcov --summary)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,21 +89,20 @@ jobs:
           lcov --capture \
             --directory lib/CMakeFiles/ipcon.dir/ \
             --output-file coverage.info \
-            --rc lcov_branch_coverage=1
+            --rc branch_coverage=1
 
           lcov --remove coverage.info '/usr/include/*' \
             -o coverage.info \
-            --rc lcov_branch_coverage=1
+            --rc branch_coverage=1
 
           echo "## Coverage Summary" > ${{ github.workspace }}/coverage.md
           echo '```' >> ${{ github.workspace }}/coverage.md
-          lcov --summary coverage.info --rc lcov_branch_coverage=1 \
-            2>&1 | grep -v "^\(Reading\|$\)" >> ${{ github.workspace }}/coverage.md
+          lcov --summary coverage.info --rc branch_coverage=1 >> ${{ github.workspace }}/coverage.md 2>&1
           echo '```' >> ${{ github.workspace }}/coverage.md
 
           genhtml coverage.info \
             --output-directory coverage \
-            --rc genhtml_branch_coverage=1
+            --rc branch_coverage=1
 
       - name: Post coverage to PR
         if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,8 +97,8 @@ jobs:
 
           echo "## Coverage Summary" > ${{ github.workspace }}/coverage.md
           echo '```' >> ${{ github.workspace }}/coverage.md
-          lcov -l coverage.info --rc lcov_branch_coverage=1 \
-            | tail -n +2 >> ${{ github.workspace }}/coverage.md
+          lcov --summary coverage.info --rc lcov_branch_coverage=1 \
+            2>&1 | grep -v "^\(Reading\|$\)" >> ${{ github.workspace }}/coverage.md
           echo '```' >> ${{ github.workspace }}/coverage.md
 
           genhtml coverage.info \


### PR DESCRIPTION
Replaces `lcov -l ... | tail -n +2` with `lcov --summary` which outputs clean overall coverage numbers:

```
Lines:      89.5% (178/199)
Functions:  92.3% (36/39)
Branches:   78.0% (39/50)
```

No more 1889% bug, no confusing 3-column Rate/Num format.

Fixes #16