### PR TITLE
ci: skip workflow on docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ name: libipcon CI
 on:
   pull_request:
     branches: [ main, master ]
+    paths-ignore:
+      - '**.md'
+      - 'Document/**'
+      - 'LICENSE'
   push:
     branches: [ main, master ]
 


### PR DESCRIPTION
Fixes #36

Adds `paths-ignore` to the `pull_request` trigger so that PRs touching only `.md`, `Document/`, or `LICENSE` don't trigger the full CI pipeline.

Pushes to `main`/`master` are unaffected — they still run regardless.